### PR TITLE
Set up multistage YAML Azure Pipelines

### DIFF
--- a/UKHO.Logging.EventHubLogProviderTest/UKHO.Logging.EventHubLogProviderTest.csproj
+++ b/UKHO.Logging.EventHubLogProviderTest/UKHO.Logging.EventHubLogProviderTest.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <AssemblyName>UKHO.Logging.EventHubLogProviderTest</AssemblyName>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,63 @@
+variables:
+  projectVersion: 1
+  configuration: Release
+  solution: UKHO.Logging.EventHubLogProvider.sln
+  progetFeed: https://proget.ukho.gov.uk/nuget/ukho.trusted/
+  
+name: $(BuildDefinitionName)_$(projectVersion).$(date:yy)$(DayOfYear)$(rev:.r)
+
+trigger: none
+
+stages:
+- stage: build
+  jobs:
+  - job: run_build
+    pool:
+      name: NautilusBuild
+    workspace:
+      clean: all
+    steps:
+    - script: dotnet restore
+      displayName: Restore Packages
+
+    - powershell: ./Apply-AssemblyVersionAndDefaults.ps1 -buildNumber $(Build.BuildNumber) -solutionDirectory $(Build.SourcesDirectory)
+      displayName: Apply Version Number
+
+    - script: dotnet build $(solution) -c $(configuration) --no-restore
+      displayName: Build Project
+
+    - script: dotnet test $(solution) --no-build -c $(configuration) --logger:trx -r $(Agent.BuildDirectory)/TestResults 
+      displayName: Test Project
+
+    - task: PublishTestResults@2
+      displayName: Publish Test Results
+      inputs:
+        testRunner: VSTest
+        testResultsFiles: '$(Agent.BuildDirectory)/TestResults/*.trx'
+        failTaskOnFailedTests: true
+        mergeTestResults: true
+
+    - script: dotnet pack $(solution) --no-build -c $(configuration) -o $(Build.ArtifactStagingDirectory)
+      displayName: Pack Project
+
+    - task: PublishPipelineArtifact@1
+      displayName: Publish Pipeline Atrifact
+      inputs:
+        path: $(Build.ArtifactStagingDirectory)
+        artifact: $(Build.DefinitionName)
+  
+- stage: deploy
+  jobs:
+  - deployment: publish
+    displayName: publish package
+    pool:
+      name: NautilusRelease
+    environment: live
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - powershell: dotnet nuget push "$(Pipeline.Workspace)/**/$("$(Build.BuildNumber)".replace('_','.')).nupkg" -k $(progetApiKey) -s $(progetFeed)
+            env:
+              progetApiKey : $(progetApiKey)
+            displayName: Publish Package


### PR DESCRIPTION
Create an Azure Pipelines YAML pipeline to replicate the current classic Build and Release pipeline. 

- This is a multistage pipeline. Multistage is currently opt in preview
  - https://devblogs.microsoft.com/devops/whats-new-with-azure-pipelines/
- The new pipeline is in https://ukhogov.visualstudio.com/Pipelines/_build?definitionId=56&_a=summary
- This uses the same triggers as the classic pipelines
  - The build must be manually triggered
  - The release will automatically deploy after the build completes
- The index symbols steps has been removed because it was harder with GitHub
  - https://docs.microsoft.com/en-us/azure/devops/artifacts/symbols/setting-up-github-sourcelinking?view=azure-devops
- Added a "don't pack" flag to the test project to make life easier when creating the NuGet package

Fixes #2