### PR TITLE
Updating Microsoft.Azure.EventHubs nuget and adding Microsoft.Azure.amqp nuget for net 6.0 compatibility

### DIFF
--- a/UKHO.Logging.EventHubLogProvider/UKHO.Logging.EventHubLogProvider.csproj
+++ b/UKHO.Logging.EventHubLogProvider/UKHO.Logging.EventHubLogProvider.csproj
@@ -16,7 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.5.12" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.3.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />


### PR DESCRIPTION
To fix the issues on Eventlogging after net6.0 upgrade, 
the following changes are done to make it work

Microsoft.Azure.EventHubs nuget is upgraded to latest ( it is currently deprecated, but work is going on to replace it with new package in PR #26 
Microsoft.Azure.amqp nuget package is added